### PR TITLE
Add simple Flask web GUI

### DIFF
--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -1,0 +1,15 @@
+FROM python:3.10-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sox libsndfile1 libsox-fmt-all ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r web_gui/requirements.txt
+
+EXPOSE 5000
+CMD ["python", "web_gui/app.py"]

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ Input audio maybe be of any sample rate, however, all audio will be resampled to
 
 Thanks to DamRsn for developing this working VST version of basic-pitch! - https://github.com/DamRsn/NeuralNote
 
+### Web GUI
+
+You can run a minimal web interface locally using Docker. The container exposes
+port `5000` and lets you upload an audio file from your browser and download the
+transcribed MIDI result.
+
+```bash
+docker build -f Dockerfile.gui -t basic-pitch-web .
+docker run -p 5000:5000 basic-pitch-web
+```
+
+Then open `http://localhost:5000` in your browser to use the interface.
+
 
 ## Contributing
 

--- a/web_gui/app.py
+++ b/web_gui/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, request, send_file, redirect, url_for
+import tempfile
+import os
+
+from basic_pitch.inference import predict
+from basic_pitch import ICASSP_2022_MODEL_PATH
+
+app = Flask(__name__)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files.get('audio_file')
+        if not file or file.filename == '':
+            return redirect(request.url)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(file.filename)[1]) as inp:
+            file.save(inp.name)
+            _, midi_data, _ = predict(inp.name, ICASSP_2022_MODEL_PATH)
+            out_fd, out_path = tempfile.mkstemp(suffix='.mid')
+            os.close(out_fd)
+            midi_data.write(out_path)
+        return send_file(out_path, as_attachment=True, download_name='transcription.mid')
+
+    return '''
+    <!doctype html>
+    <title>Basic Pitch Web</title>
+    <h1>Upload audio file</h1>
+    <form method=post enctype=multipart/form-data>
+      <input type=file name=audio_file accept="audio/*">
+      <input type=submit value=Transcribe>
+    </form>
+    '''
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/web_gui/requirements.txt
+++ b/web_gui/requirements.txt
@@ -1,0 +1,2 @@
+flask
+basic-pitch


### PR DESCRIPTION
## Summary
- add a minimal Flask app for uploading audio and returning a MIDI file
- provide a small Dockerfile to run the web GUI
- document how to start the GUI container in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*

------
https://chatgpt.com/codex/tasks/task_e_6848d1ee59f88324b8d61d35e953870e